### PR TITLE
fix(nginx): Add rule for pages resources

### DIFF
--- a/nginx/conf.d/wise.conf
+++ b/nginx/conf.d/wise.conf
@@ -11,6 +11,13 @@ server {
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
     }
+    location /pages/resources/ {
+        proxy_pass http://wise-api-server:8080;
+	proxy_set_header Host $host:$server_port;
+	proxy_set_header X-Forwarded-Host $server_name;
+    	proxy_set_header X-Real-IP $remote_addr;
+    	proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    }
     location /teacher/management {
         proxy_pass http://wise-api-server:8080;
         proxy_set_header Host $host:$server_port;


### PR DESCRIPTION
## Summary

This PR adds an nginx rule to proxy `/pages/resources/` requests to the WISE API server.

## Reason

The Batch Create User Accounts page links to a sample CSV file under `/pages/resources/`. When WISE is served with Docker, this route needs to be handled by the API server instead of the client server.

## Change

Added a specific nginx location block for `/pages/resources/` and proxied it to `http://wise-api-server:8080`.

## Testing

Tested on our TWISE Docker deployment by confirming that:

`/pages/resources/WISE_BatchCreateUserAccounts_Sample.csv`

returns the sample CSV file successfully.